### PR TITLE
Fixing spelling error

### DIFF
--- a/code/dice/__init__.py
+++ b/code/dice/__init__.py
@@ -1,1 +1,1 @@
-from .dice import Dice
+from .dice import Die


### PR DESCRIPTION
Dice should have been Die.


This was causing me the error:

ImportError while importing test module 'test/test_dice.py'.
Hint: make sure your test modules/packages have valid Python names.                                                                                           
Traceback:                                                                                                                                                    
__init__.py:1: in <module>                                                                                                                                    
    from .dice import Dice   

when attempting to run "pytest test/test_dice.py::test_valid_roll" as is suggested in the 4th code box in the testing randomness episode.
